### PR TITLE
update readme for Learn IDE with multiple http servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Don't worry! We've very cleverly solved this problem for the purposes of this pr
 
 You will deploy this website locally by running it on a server on your computer. Here's how:
 
-**Important if you're using the Learn IDE:** If you're using the Learn IDE and you cannot open up another terminal window (one for the jekyll server and one for the `rspec` command) you can just run the server as a background job (`jekyll serve &`). For more information on background jobs in bash, take a look at this readme: https://github.com/learn-co-curriculum/bash-background-jobs/
+**Important if you're using the Learn IDE:** If you're using the Learn IDE and you cannot open up another terminal window (one for the jekyll server and one for the `rspec` command) you can just run the server as a background job (`jekyll serve --detach`). For more information on background jobs in bash, take a look at this readme: https://github.com/learn-co-curriculum/bash-background-jobs/
 
 * In the terminal, run `jekyll serve`. You'll see something like this:
 
@@ -41,9 +41,11 @@ Configuration file: /Users/sophiedebenedetto/Desktop/Dev/oo-student-scraper/fixt
 
 Most of that isn't important. We do want to pay attention to the second to last line, however. `Server address: http://127.0.0.1:4000/`. This tells us what port on our local server we can view the website at. Open up your browser and paste in `http://127.0.0.1:4000/` and you should see your student site! (note: `http://127.0.0.1` is often referred to as `localhost` and many browsers and other systems [use this term](https://en.wikipedia.org/wiki/Localhost). They are effectively interchangable, i.e., you could just as easily paste `localhost:4000` into a browser and it would be the same.)
 
-**Important:** Make sure you are running the site via the `jekyll server` when you run `rspec`. The tests are using the code you will write that sends a web request and scrapes a site. The web request that is getting sent is to `http://127.0.0.1:4000/`, the host and port that Jekyll will run the site on when you execute `jekyll serve`. So, if your connection to the server on port 4000 isn't running, the test suite can't execute your code.  You will need to open a second tab in your command line, in order to run `rspec` while Jekyll is also running.
+**Important:** Make sure you are running the site via the `jekyll serve` when you run `rspec`. The tests are using the code you will write that sends a web request and scrapes a site. The web request that is getting sent is to `http://127.0.0.1:4000/`, the host and port that Jekyll will run the site on when you execute `jekyll serve`. So, if your connection to the server on port 4000 isn't running, the test suite can't execute your code.  You will need to open a second tab in your command line, in order to run `rspec` while Jekyll is also running.
 
-**Important if you're using the Learn IDE:** If you're using the Learn IDE you won't be able to see the output of the jekyll server (but the it's still needed for the test). If you want to look at the web site you can also run your `httpserver &`. Now you'll have two background tasks, one your can use to view the page (httpserver) and one so that test can see the page (jekyll server).
+**Important if you're using the Learn IDE:** If you're using the Learn IDE you won't be able to see the output of the Jekyll server (but the it's still needed for the test). If you want to look at the web site you can also run your `httpserver`. **Note** that you cannot run a Jekyll server and httpserver at the same time on the Learn IDE because it only provides one port. Use `jekyll serve --detach` only for running tests and be sure to pay attention to the command needed to kill the server so you can then run `httpserver`.
+
+If you get a message telling you that the address is already in use, use `lsof -wni tcp:1234` (replacing `1234` with the port your IDE uses) to find the process using the port and then `kill 54321` (replacing `54321` with the process using the port) to then free up that port again.
 
 ## Instructions
 


### PR DESCRIPTION
Students cannot run Jekyll and httpserver with the Learn IDE so I updated the readme to clarify this and give some help if students run into address already in use. 

https://github.com/learn-co-students/oo-student-scraper-v-000/issues/224
